### PR TITLE
Replace concrete KafkaConsumers with Suppliers

### DIFF
--- a/example/src/main/java/com/markosindustries/distroboy/example/ExampleKafkaConsumer.java
+++ b/example/src/main/java/com/markosindustries/distroboy/example/ExampleKafkaConsumer.java
@@ -23,7 +23,6 @@ import com.markosindustries.distroboy.kafka.LatestKafkaOffsetSpec;
 import com.markosindustries.distroboy.kafka.ReadKafkaTopicPartitionRange;
 import java.util.List;
 import java.util.Locale;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.slf4j.Logger;
@@ -54,9 +53,7 @@ public interface ExampleKafkaConsumer {
     cluster
         .execute(
             DistributedOpSequence.readFrom(
-                    new KafkaTopicPartitionsSource(
-                        () -> new KafkaConsumer<byte[], byte[]>(kafkaConfig),
-                        List.of("distroboy.example.topic")))
+                    new KafkaTopicPartitionsSource(kafkaConfig, List.of("distroboy.example.topic")))
                 .flatMap(
                     // TODO: This is an example only. In a real job, you'd likely want to use
                     //  timestamp-based offsets in the past if possible, so that you can ensure
@@ -64,9 +61,7 @@ public interface ExampleKafkaConsumer {
                     //  only really safe when the topic isn't being cleaned or added to when the
                     //  distributed operation is running
                     new ReadKafkaTopicPartitionRange<>(
-                        () -> new KafkaConsumer<byte[], byte[]>(kafkaConfig),
-                        new EarliestKafkaOffsetSpec(),
-                        new LatestKafkaOffsetSpec()))
+                        kafkaConfig, new EarliestKafkaOffsetSpec(), new LatestKafkaOffsetSpec()))
                 .count())
         .onClusterLeader(
             events -> {

--- a/kafka/src/main/java/com/markosindustries/distroboy/kafka/KafkaTopicPartitionsSource.java
+++ b/kafka/src/main/java/com/markosindustries/distroboy/kafka/KafkaTopicPartitionsSource.java
@@ -5,6 +5,7 @@ import com.markosindustries.distroboy.core.operations.DataSource;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.PartitionInfo;
@@ -18,11 +19,14 @@ public class KafkaTopicPartitionsSource implements DataSource<List<TopicPartitio
   private final List<TopicPartition> topicPartitions;
 
   /**
-   * @param kafkaConsumer A {@link org.apache.kafka.clients.consumer.KafkaConsumer} to communicate
-   *     with Kafka via
+   * @param kafkaConsumerSupplier A Supplier of {@link
+   *     org.apache.kafka.clients.consumer.KafkaConsumer} to communicate with Kafka via
    * @param topics The set of topics to retrieve {@link TopicPartition}s for
    */
-  public KafkaTopicPartitionsSource(Consumer<?, ?> kafkaConsumer, Collection<String> topics) {
+  public KafkaTopicPartitionsSource(
+      Supplier<Consumer<?, ?>> kafkaConsumerSupplier, Collection<String> topics) {
+    final Consumer<?, ?> kafkaConsumer = kafkaConsumerSupplier.get();
+
     this.topicPartitions =
         topics.stream()
             .flatMap(

--- a/kafka/src/main/java/com/markosindustries/distroboy/kafka/ReadKafkaTopicPartitionRange.java
+++ b/kafka/src/main/java/com/markosindustries/distroboy/kafka/ReadKafkaTopicPartitionRange.java
@@ -1,10 +1,9 @@
 package com.markosindustries.distroboy.kafka;
 
+import com.google.common.collect.ImmutableMap;
 import com.markosindustries.distroboy.core.iterators.IteratorWithResources;
 import com.markosindustries.distroboy.core.operations.FlatMapOp;
 import java.util.List;
-import java.util.function.Supplier;
-import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 
@@ -19,29 +18,30 @@ import org.apache.kafka.common.TopicPartition;
  */
 public class ReadKafkaTopicPartitionRange<K, V>
     implements FlatMapOp<List<TopicPartition>, ConsumerRecord<K, V>> {
-  private final Consumer<K, V> kafkaConsumer;
+  private final ImmutableMap<String, Object> kafkaConfiguration;
   private final KafkaOffsetSpec startOffsetInclusiveSpec;
   private final KafkaOffsetSpec endOffsetExclusiveSpec;
 
   /**
-   * @param kafkaConsumerSupplier A Supplier of {@link
-   *     org.apache.kafka.clients.consumer.KafkaConsumer} to communicate with Kafka via
+   * @param kafkaConfiguration An ImmutableMap of <a
+   *     href="http://kafka.apache.org/documentation.html#consumerconfigs">Configuration</a> needed
+   *     * to instantiate a KafkaConsumer {@link org.apache.kafka.clients.consumer.KafkaConsumer} to
+   *     * communicate with Kafka via
    * @param startOffsetInclusiveSpec The starting offset spec (inclusive)
    * @param endOffsetExclusiveSpec The end offset spec (exclusive)
    */
   public ReadKafkaTopicPartitionRange(
-      Supplier<Consumer<K, V>> kafkaConsumerSupplier,
+      ImmutableMap<String, Object> kafkaConfiguration,
       KafkaOffsetSpec startOffsetInclusiveSpec,
       KafkaOffsetSpec endOffsetExclusiveSpec) {
-    this.kafkaConsumer = kafkaConsumerSupplier.get();
+    this.kafkaConfiguration = kafkaConfiguration;
     this.startOffsetInclusiveSpec = startOffsetInclusiveSpec;
     this.endOffsetExclusiveSpec = endOffsetExclusiveSpec;
   }
 
   @Override
   public IteratorWithResources<ConsumerRecord<K, V>> flatMap(List<TopicPartition> input) {
-    return IteratorWithResources.from(
-        new KafkaTopicPartitionsIterator<K, V>(
-            kafkaConsumer, input, startOffsetInclusiveSpec, endOffsetExclusiveSpec));
+    return new KafkaTopicPartitionsIterator<K, V>(
+        kafkaConfiguration, input, startOffsetInclusiveSpec, endOffsetExclusiveSpec);
   }
 }

--- a/kafka/src/main/java/com/markosindustries/distroboy/kafka/ReadKafkaTopicPartitionRange.java
+++ b/kafka/src/main/java/com/markosindustries/distroboy/kafka/ReadKafkaTopicPartitionRange.java
@@ -3,6 +3,7 @@ package com.markosindustries.distroboy.kafka;
 import com.markosindustries.distroboy.core.iterators.IteratorWithResources;
 import com.markosindustries.distroboy.core.operations.FlatMapOp;
 import java.util.List;
+import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -23,16 +24,16 @@ public class ReadKafkaTopicPartitionRange<K, V>
   private final KafkaOffsetSpec endOffsetExclusiveSpec;
 
   /**
-   * @param kafkaConsumer A {@link org.apache.kafka.clients.consumer.KafkaConsumer} to communicate
-   *     with Kafka via
+   * @param kafkaConsumerSupplier A Supplier of {@link
+   *     org.apache.kafka.clients.consumer.KafkaConsumer} to communicate with Kafka via
    * @param startOffsetInclusiveSpec The starting offset spec (inclusive)
    * @param endOffsetExclusiveSpec The end offset spec (exclusive)
    */
   public ReadKafkaTopicPartitionRange(
-      Consumer<K, V> kafkaConsumer,
+      Supplier<Consumer<K, V>> kafkaConsumerSupplier,
       KafkaOffsetSpec startOffsetInclusiveSpec,
       KafkaOffsetSpec endOffsetExclusiveSpec) {
-    this.kafkaConsumer = kafkaConsumer;
+    this.kafkaConsumer = kafkaConsumerSupplier.get();
     this.startOffsetInclusiveSpec = startOffsetInclusiveSpec;
     this.endOffsetExclusiveSpec = endOffsetExclusiveSpec;
   }


### PR DESCRIPTION
KafkaConsumers are not thread safe - using the same KafkaConsumer in both the `KafkaTopicPartitionSource` and `ReadKafkaTopicPartitionRange` would result in exceptions being thrown by the consumer as it detected being used on different threads.

This change replaces the KafkaConsumers with Suppliers to step around this issue.